### PR TITLE
Update node-pty-prebuilt-multiarch

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.2.0",
-    "node-pty-prebuilt-multiarch": "^0.9.0",
+    "node-pty-prebuilt-multiarch": "^0.10.1-pre.5",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/master",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Update node-pty-prebuilt-multiarch from 0.9.0 to 0.10.1-pre.5. According to [their author's comment](https://github.com/oznu/node-pty-prebuilt-multiarch/issues/17#issuecomment-1105934956), 0.10.1-pre.5 supports Electron 11.4.7 on which Atom 1.63.1 is based.

### Pull request details
<!--Tick the appropriate box by adding an x in between the [] to ID the PR type-->
- [ ] This PR is a bug fix
- [ ] This PR implements a new feature or introduces new behavior.

### Description of the change
<!-- We must be able to understand the design of your change from this description.
Please walk us through the concepts. -->

### Notes
<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand.
-->
